### PR TITLE
Add user browser puppeteering tool

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+exclude = .venv

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A web scraping server that implements the Minecraft Control Protocol (MCP) using
 - Link extraction with full URL resolution
 - Language detection
 - Headless Chrome browser automation
+- Open URLs in your existing browser session
 - FastAPI-based REST API
 - MCP protocol implementation
 
@@ -72,6 +73,18 @@ The server will start on `http://localhost:8000` by default.
 - **Method**: POST
 - **Command**: `ping`
 - **Response**: Server status and version information
+
+#### Open Browser
+- **URL**: `/mcp`
+- **Method**: POST
+- **Command**: `open_browser`
+- **Parameters**:
+  ```json
+  {
+    "url": "https://example.com"
+  }
+  ```
+- **Response**: Confirmation that the URL was opened using your browser session
 
 ### Health Check
 - **URL**: `/health`

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 from fastmcp import FastMCP
-from pydantic import HttpUrl
-from typing import Dict, Any, List, Tuple
+from typing import Dict, Any, List
 import logging
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
@@ -14,6 +13,7 @@ import re
 import time
 import os
 from urllib.parse import urljoin
+import sys
 
 # Configure logging
 log_file = os.path.join(os.path.expanduser("~"), "Downloads", "mcp.log")
@@ -34,10 +34,27 @@ chrome_options.add_argument('--no-sandbox')
 chrome_options.add_argument('--disable-dev-shm-usage')
 chrome_options.add_argument('--disable-gpu')
 chrome_options.add_argument('--window-size=1920,1080')
-chrome_options.add_argument('--user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36')
+user_agent = (
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+    'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36'
+)
+chrome_options.add_argument(f'--user-agent={user_agent}')
 
 # Initialize FastMCP
 mcp = FastMCP("Web Scraper MCP 🚀")
+
+
+def _get_chrome_profile_path() -> str:
+    """Return the default Chrome user profile path based on the OS."""
+    home = os.path.expanduser("~")
+    if sys.platform == "darwin":
+        return os.path.join(home, "Library", "Application Support", "Google", "Chrome")
+    if sys.platform.startswith("linux"):
+        return os.path.join(home, ".config", "google-chrome")
+    if sys.platform.startswith("win"):
+        return os.path.join(home, "AppData", "Local", "Google", "Chrome", "User Data")
+    raise RuntimeError("Unsupported operating system for locating Chrome profile")
+
 
 class WebScraper:
     def __init__(self):
@@ -138,33 +155,33 @@ class WebScraper:
                 EC.presence_of_element_located(("tag name", "body"))
             )
             time.sleep(2)  # Shorter wait time for links
-            
+
             # Get the page source and parse with BeautifulSoup
             html_content = self.driver.page_source
             soup = BeautifulSoup(html_content, 'html.parser')
-            
+
             # Extract all links
             links = []
             for a_tag in soup.find_all('a', href=True):
                 href = a_tag['href']
                 text = a_tag.get_text(strip=True)
-                
+
                 # Skip empty links and javascript:void(0)
                 if not href or href.startswith('javascript:'):
                     continue
-                    
+
                 # Make relative URLs absolute
                 if not href.startswith(('http://', 'https://')):
                     href = urljoin(url, href)
-                
+
                 links.append({
                     "url": href,
                     "text": text if text else href
                 })
-            
+
             logger.info(f"Successfully extracted {len(links)} links from {url}")
             return links
-            
+
         except Exception as e:
             error_msg = f"Error extracting links from {url}: {str(e)}"
             logger.error(error_msg)
@@ -180,37 +197,37 @@ class WebScraper:
                 EC.presence_of_element_located(("tag name", "body"))
             )
             time.sleep(5)
-            
+
             # Get the page source and parse with BeautifulSoup
             html_content = self.driver.page_source
             soup = BeautifulSoup(html_content, 'html.parser')
-            
+
             # Extract main content
             text = self._extract_main_content(soup)
-            
+
             # Clean and process the text
             lines = text.split('\n')
             cleaned_lines = []
-            
+
             for line in lines:
                 cleaned_line = self._clean_text(line)
                 if self._is_relevant_content(cleaned_line):
                     cleaned_lines.append(cleaned_line)
-            
+
             # Join lines and remove duplicate content
             text = '\n'.join(cleaned_lines)
             text = re.sub(r'\n\s*\n', '\n\n', text)  # Remove multiple newlines
-            
+
             # Optional: Detect language and filter non-English content
             try:
                 if detect(text) != 'en':
                     logger.warning(f"Non-English content detected from {url}")
             except LangDetectException:
                 logger.warning(f"Could not detect language for content from {url}")
-            
+
             logger.info(f"Successfully extracted and cleaned text content from {url}")
             return text
-            
+
         except Exception as e:
             error_msg = f"Error fetching content from {url}: {str(e)}"
             logger.error(error_msg)
@@ -224,8 +241,29 @@ class WebScraper:
             except Exception as e:
                 logger.error(f"Error during WebDriver cleanup: {str(e)}")
 
+
+@mcp.tool
+def open_in_user_browser(url: str) -> Dict[str, Any]:
+    """Open a URL in the user's regular Chrome profile."""
+    try:
+        profile = _get_chrome_profile_path()
+        options = Options()
+        options.add_argument(f"--user-data-dir={profile}")
+        driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=options)
+        driver.get(url)
+        return {
+            "status": "success",
+            "message": f"Opened {url} in the user browser",
+            "data": None,
+        }
+    except Exception as e:
+        logger.error(f"Failed to open browser for {url}: {str(e)}")
+        return {"status": "error", "message": str(e), "data": None}
+
+
 # Initialize WebScraper
 scraper = WebScraper()
+
 
 @mcp.tool
 def scrape_website(url: str) -> Dict[str, Any]:
@@ -245,6 +283,7 @@ def scrape_website(url: str) -> Dict[str, Any]:
             "data": None
         }
 
+
 @mcp.tool
 def extract_links(url: str) -> Dict[str, Any]:
     """Extract all links from a specified URL"""
@@ -263,6 +302,7 @@ def extract_links(url: str) -> Dict[str, Any]:
             "data": None
         }
 
+
 @mcp.tool
 def ping() -> Dict[str, Any]:
     """Check if the server is responsive"""
@@ -272,8 +312,9 @@ def ping() -> Dict[str, Any]:
         "data": {"timestamp": time.time()}
     }
 
+
 if __name__ == "__main__":
     try:
         mcp.run()
     finally:
-        scraper.cleanup() 
+        scraper.cleanup()

--- a/mcp.json
+++ b/mcp.json
@@ -29,6 +29,8 @@
         "get links",
         "find links",
         "list links",
+        "open browser",
+        "open website",
         "ping",
         "check server"
       ],
@@ -70,6 +72,16 @@
         "ping": {
           "description": "Check if the server is responsive",
           "parameters": {}
+        },
+        "open_browser": {
+          "description": "Open a URL in the user's browser with their cookies",
+          "parameters": {
+            "url": {
+              "type": "string",
+              "description": "The URL to open",
+              "required": true
+            }
+          }
         }
       }
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,5 +59,6 @@ dependencies = [
   "webdriver-manager==4.0.2",
   "websocket-client==1.8.0",
   "wsproto==1.2.0",
-  "pyperclip==1.8.2"
+  "pyperclip==1.8.2",
+  "flake8==7.2.0"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ cryptography==45.0.4
 exceptiongroup==1.3.0
 fastapi==0.110.0
 fastmcp==2.8.0
+flake8==7.2.0
 h11==0.16.0
 httpcore==1.0.9
 httpx==0.28.1
@@ -18,17 +19,21 @@ httpx-sse==0.4.0
 idna==3.10
 langdetect==1.0.9
 markdown-it-py==3.0.0
+mccabe==0.7.0
 mcp==1.9.3
 mdurl==0.1.2
 openapi-pydantic==0.5.1
 outcome==1.3.0.post0
 packaging==25.0
 pip==25.1.1
+pycodestyle==2.13.0
 pycparser==2.22
 pydantic==2.11.5
 pydantic-core==2.33.2
 pydantic-settings==2.9.1
+pyflakes==3.3.2
 pygments==2.19.1
+pyperclip==1.8.2
 pysocks==1.7.1
 python-dotenv==1.1.0
 python-multipart==0.0.20
@@ -52,4 +57,3 @@ uvicorn==0.27.1
 webdriver-manager==4.0.2
 websocket-client==1.8.0
 wsproto==1.2.0
-pyperclip==1.8.2

--- a/update_mcp_path.py
+++ b/update_mcp_path.py
@@ -2,25 +2,27 @@ import json
 import os
 import pyperclip
 
+
 def update_mcp_path():
     # Get current directory
     current_dir = os.getcwd()
-    
+
     # Read the mcp.json file
     with open('mcp.json', 'r') as f:
         mcp_data = json.load(f)
-    
+
     # Update the system directory in the args array
     mcp_data['mcpServers']['web-content']['args'][2] = current_dir
-    
+
     # Convert the updated dictionary to a formatted JSON string
     updated_json = json.dumps(mcp_data, indent=2)
-    
+
     # Copy the updated JSON to clipboard
     pyperclip.copy(updated_json)
-    
+
     print(f"Updated directory in memory: {current_dir}")
     print("Updated mcp.json content has been copied to clipboard!")
 
+
 if __name__ == "__main__":
-    update_mcp_path() 
+    update_mcp_path()


### PR DESCRIPTION
## Summary
- add a tool to open URLs using the current Chrome profile
- expose the tool via MCP config and document it in README
- include flake8 configuration and dependency
- clean up Python style to satisfy flake8

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c0d9f3924832b84ae4067cf737a19