### PR TITLE
fix agent to use updated langchain ollama

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -3,7 +3,7 @@ import os
 # Ensure logging directory exists before importing main
 os.makedirs(os.path.join(os.path.expanduser("~"), "Downloads"), exist_ok=True)
 
-from langchain_community.chat_models import ChatOllama  # noqa: E402
+from langchain_ollama import ChatOllama  # noqa: E402
 from langchain_core.messages import HumanMessage  # noqa: E402
 from langchain_core.tools import tool  # noqa: E402
 from langgraph.prebuilt import create_react_agent  # noqa: E402

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,8 @@ dependencies = [
   "xxhash==3.5.0",
   "zstandard==0.23.0",
   "pyperclip==1.8.2",
-  "flake8==7.2.0"
+  "flake8==7.2.0",
+  "langchain-ollama==0.3.3",
 ]
 
 [tool.ruff]

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ jsonpointer==3.0.0
 langchain==0.3.25
 langchain-community==0.3.25
 langchain-core==0.3.65
+langchain-ollama==0.3.3
 langchain-text-splitters==0.3.8
 langdetect==1.0.9
 langgraph==0.4.8


### PR DESCRIPTION
## Summary
- replace deprecated ChatOllama import
- add langchain-ollama to project dependencies

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851204639b4832b9154fa4443097aae