### PR TITLE
fix: add missing return type hints

### DIFF
--- a/main.py
+++ b/main.py
@@ -58,7 +58,7 @@ def _get_chrome_profile_path() -> str:
 
 
 class WebScraper:
-    def __init__(self):
+    def __init__(self) -> None:
         self.driver = None
         # Elements to remove from the content
         self.unwanted_elements = [
@@ -86,7 +86,7 @@ class WebScraper:
             logger.error(f"Failed to initialize Chrome WebDriver: {str(e)}")
             self.driver = None
 
-    def _ensure_driver(self):
+    def _ensure_driver(self) -> None:
         if self.driver:
             return
         try:
@@ -234,7 +234,7 @@ class WebScraper:
             logger.error(error_msg)
             raise Exception(error_msg)
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         if self.driver:
             try:
                 self.driver.quit()

--- a/update_mcp_path.py
+++ b/update_mcp_path.py
@@ -3,7 +3,7 @@ import os
 import pyperclip
 
 
-def update_mcp_path():
+def update_mcp_path() -> None:
     # Get current directory
     current_dir = os.getcwd()
 


### PR DESCRIPTION
## Summary
- silence ruff ANN warnings by adding return type hints to helper methods

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68513dd4a584832ba289f5d48fc45460