### PR TITLE
add agent http endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ python main.py
 
 The server will start on `http://localhost:8000` by default.
 
+To run the agent endpoint:
+```bash
+python agents.py --serve
+```
+This starts another server on `http://localhost:8001` by default.
+
 ## API Endpoints
 
 ### MCP Endpoints
@@ -97,6 +103,17 @@ The server will start on `http://localhost:8000` by default.
   }
   ```
 - **Response**: Confirmation that the URL was opened using your browser session
+
+#### Query Agent
+- **URL**: `/agent`
+- **Method**: POST
+- **Body**:
+  ```json
+  {
+    "query": "Your question here"
+  }
+  ```
+- **Response**: Agent-generated answer
 
 ### Health Check
 - **URL**: `/health`

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A web scraping server that implements the Minecraft Control Protocol (MCP) using
 - Open URLs in your existing browser session
 - FastAPI-based REST API
 - MCP protocol implementation
+- LLM-powered agent endpoint for custom queries
 
 ## Prerequisites
 

--- a/tests/test_agents_endpoint.py
+++ b/tests/test_agents_endpoint.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-import importlib
+import importlib.util
 import pytest
 
 required_modules = [

--- a/tests/test_agents_endpoint.py
+++ b/tests/test_agents_endpoint.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import importlib
+import pytest
+
+required_modules = [
+    "fastapi",
+    "langchain_ollama",
+    "langchain_core",
+    "langgraph",
+    "fastmcp",
+    "selenium",
+]
+for module in required_modules:
+    if importlib.util.find_spec(module) is None:
+        pytest.skip(f"{module} not available", allow_module_level=True)
+
+import agents  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+def test_agent_endpoint(monkeypatch):
+    def fake_run(query: str) -> str:
+        return "dummy response"
+    monkeypatch.setattr(agents, "run", fake_run)
+    client = TestClient(agents.app)
+    resp = client.post("/agent", json={"query": "hello"})
+    assert resp.status_code == 200
+    assert resp.json() == {"response": "dummy response"}


### PR DESCRIPTION
## Summary
- expose a new `/agent` HTTP endpoint for queries
- document how to run the agent server
- cover the new endpoint with a test

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858f0f4a068832b9975378671452b7d