### PR TITLE
add streaming option to agents

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -4,7 +4,7 @@ import os
 os.makedirs(os.path.join(os.path.expanduser("~"), "Downloads"), exist_ok=True)
 
 from langchain_ollama import ChatOllama  # noqa: E402
-from langchain_core.messages import HumanMessage  # noqa: E402
+from langchain_core.messages import AIMessage, HumanMessage  # noqa: E402
 from langchain_core.tools import tool  # noqa: E402
 from langgraph.prebuilt import create_react_agent  # noqa: E402
 
@@ -31,8 +31,35 @@ def run(query: str) -> str:
     return messages[-1].content if messages else ""
 
 
+def stream_response(query: str):
+    """Yield the response text incrementally."""
+    state = {"messages": [HumanMessage(content=query)]}
+    previous = ""
+    for step in agent.stream(state):
+        messages = step.get("messages", [])
+        if not messages:
+            continue
+        last = messages[-1]
+        if isinstance(last, AIMessage):
+            content = last.content
+            delta = content[len(previous):] if content.startswith(previous) else content
+            previous = content
+            if delta:
+                yield delta
+
+
 if __name__ == "__main__":
     import sys
 
+    stream_flag = "--stream" in sys.argv
+    if stream_flag:
+        sys.argv.remove("--stream")
+
     question = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else input("Query: ")
-    print(run(question))
+
+    if stream_flag:
+        for chunk in stream_response(question):
+            print(chunk, end="", flush=True)
+        print()
+    else:
+        print(run(question))


### PR DESCRIPTION
## Summary
- support streaming token output from `ChatOllama`
- allow streaming via `--stream` CLI flag

## Testing
- `ruff check agents.py`
- `flake8 agents.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4ded5d14832b9f3e66f8411b3aee