### PR TITLE
combine run and stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ Logs are written to `~/Downloads/mcp.log` and include:
 - Error messages and exceptions
 You can adjust the verbosity with the `--log-level` flag when starting the server.
 
+## Agent CLI
+
+Use `agents.py` to chat with the model directly. Streaming output relies on the
+`create_react_agent` streaming API described in the `LangGraph streaming docs <https://python.langchain.com/docs/guides/langgraph/streaming>`_.
+For information about Ollama's client parameters see the `Ollama API docs <https://github.com/jmorganca/ollama/blob/main/docs/api.md>`_.
+
+```bash
+python agents.py "your question"  # returns a single response
+python agents.py "your question" --stream  # stream tokens to the console
+```
+
 ## Project Structure
 
 - `main.py`: Core server implementation and MCP endpoints

--- a/agents.py
+++ b/agents.py
@@ -7,6 +7,8 @@ from langchain_ollama import ChatOllama  # noqa: E402
 from langchain_core.messages import HumanMessage  # noqa: E402
 from langchain_core.tools import tool  # noqa: E402
 from langgraph.prebuilt import create_react_agent  # noqa: E402
+
+# ollama's python client docs: https://github.com/jmorganca/ollama/blob/main/docs/api.md
 from ollama import Client  # noqa: E402
 
 import main  # noqa: E402
@@ -26,30 +28,39 @@ TOOLS = [
 agent = create_react_agent(llm, TOOLS)
 
 
-def run(query: str) -> str:
-    """Return agent response for the given query."""
-    result = agent.invoke({"messages": [HumanMessage(content=query)]})
+def chat(query: str, *, stream: bool = False) -> str:
+    """Return agent response.
+
+    When ``stream`` is ``True`` the response is printed token by token using
+    :func:`langgraph.prebuilt.create_react_agent` streaming as described in the
+    `LangGraph streaming docs <https://python.langchain.com/docs/guides/langgraph/streaming>`_.
+    For details on the Ollama client see the
+    `Ollama API docs <https://github.com/jmorganca/ollama/blob/main/docs/api.md>`_.
+    """
+
+    inputs = {"messages": [HumanMessage(content=query)]}
+    if stream:
+        tokens = []
+        for _, mode, payload in agent.stream(inputs, stream_mode="messages"):
+            if mode == "messages":
+                message, _meta = payload
+                if getattr(message, "content", None):
+                    print(message.content, end="", flush=True)
+                    tokens.append(message.content)
+        print()
+        return "".join(tokens)
+    result = agent.invoke(inputs)
     messages = result.get("messages", [])
     return messages[-1].content if messages else ""
 
 
-def stream(query: str) -> None:
-    """Stream response tokens for the given query."""
-    stream = client.chat(
-        model="qwen3:4b",
-        messages=[{"role": "user", "content": query}],
-        stream=True,
-    )
-    for chunk in stream:
-        message = chunk.get("message", {})
-        content = message.get("content")
-        if content:
-            print(content, end="", flush=True)
-    print()
-
-
 if __name__ == "__main__":
-    import sys
+    import argparse
 
-    question = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else input("Query: ")
-    stream(question)
+    parser = argparse.ArgumentParser(description="Interact with the agent")
+    parser.add_argument("query", nargs="*", help="Question to ask")
+    parser.add_argument("--stream", action="store_true", help="Stream tokens")
+    args = parser.parse_args()
+
+    question = " ".join(args.query) if args.query else input("Query: ")
+    chat(question, stream=args.stream)


### PR DESCRIPTION
## Summary
- build a single chat helper that supports token streaming
- expose CLI flags to control streaming
- document streaming in README

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_685e96e092dc832bb528fe05f6df4aae