### PR TITLE
ensure webdriver cleanup when streaming tools

### DIFF
--- a/agents_stream_tools.py
+++ b/agents_stream_tools.py
@@ -70,6 +70,10 @@ def run(query: str) -> None:
 
 if __name__ == "__main__":
     import sys
+    from tools.webscraper import scraper
 
     query = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else input("Query: ")
-    run(query)
+    try:
+        run(query)
+    finally:
+        scraper.cleanup()


### PR DESCRIPTION
## Summary
- quit Chrome WebDriver when exiting `agents_stream_tools.py`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865e9ab8738832b8836bcbdc0465ae7