### PR TITLE
centralize webdriver creation

### DIFF
--- a/tools/open_in_user_browser.py
+++ b/tools/open_in_user_browser.py
@@ -1,12 +1,9 @@
 from typing import Dict, Any
 import logging
-from selenium import webdriver
-from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.chrome.options import Options
-from webdriver_manager.chrome import ChromeDriverManager
 
 from .mcp import mcp
-from .webscraper import _get_chrome_profile_path
+from .webscraper import _get_chrome_profile_path, create_driver
 
 logger = logging.getLogger(__name__)
 
@@ -18,9 +15,7 @@ def open_in_user_browser(url: str) -> Dict[str, Any]:
         profile = _get_chrome_profile_path()
         options = Options()
         options.add_argument(f"--user-data-dir={profile}")
-        driver = webdriver.Chrome(
-            service=Service(ChromeDriverManager().install()), options=options
-        )
+        driver = create_driver(options)
         driver.get(url)
         page_source = driver.page_source
         return {

--- a/tools/webscraper.py
+++ b/tools/webscraper.py
@@ -63,6 +63,21 @@ def _get_chrome_binary() -> Optional[str]:
     return None
 
 
+def create_driver(opts: Optional[Options] = None) -> WebDriver:
+    """Initialize and return a Chrome WebDriver."""
+    options = opts or chrome_options
+    binary = _get_chrome_binary()
+    if binary:
+        options.binary_location = binary
+        logger.info(f"Using Chrome binary at {binary}")
+    else:
+        logger.warning("Chrome binary not found; relying on default discovery")
+
+    return webdriver.Chrome(
+        service=Service(ChromeDriverManager().install()), options=options
+    )
+
+
 class WebScraper:
     def __init__(self) -> None:
         self.driver: Optional[WebDriver] = None
@@ -84,18 +99,8 @@ class WebScraper:
             re.compile(r'cookie|privacy|terms|conditions', re.IGNORECASE)
         ]
         try:
-            binary = _get_chrome_binary()
-            if binary:
-                chrome_options.binary_location = binary
-                logger.info(f"Using Chrome binary at {binary}")
-            else:
-                logger.warning("Chrome binary not found; relying on default discovery")
-
             logger.info("Initializing Chrome WebDriver...")
-            self.driver = webdriver.Chrome(
-                service=Service(ChromeDriverManager().install()),
-                options=chrome_options,
-            )
+            self.driver = create_driver()
             logger.info("Chrome WebDriver initialized successfully")
         except Exception as e:
             logger.error(f"Failed to initialize Chrome WebDriver: {str(e)}")
@@ -106,17 +111,7 @@ class WebScraper:
             return
         try:
             logger.info("Attempting to reinitialize Chrome WebDriver...")
-            binary = _get_chrome_binary()
-            if binary:
-                chrome_options.binary_location = binary
-                logger.info(f"Using Chrome binary at {binary}")
-            else:
-                logger.warning("Chrome binary not found; relying on default discovery")
-
-            self.driver = webdriver.Chrome(
-                service=Service(ChromeDriverManager().install()),
-                options=chrome_options,
-            )
+            self.driver = create_driver()
             logger.info("Chrome WebDriver reinitialized successfully")
         except Exception as e:
             error_msg = f"Failed to initialize Chrome WebDriver: {str(e)}"


### PR DESCRIPTION
## Summary
- add `create_driver` helper in `webscraper`
- use helper in web scraper initialization
- use helper in `open_in_user_browser`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865ee0fa190832ba00f542d663e453b