### PR TITLE
set default log level to warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Logs are written to `~/Downloads/mcp.log` and include:
 - Web scraping operations
 - Error messages and exceptions
 You can adjust the verbosity with the `--log-level` flag when starting the server.
+By default, logs use the `warning` level.
 
 ## Project Structure
 

--- a/main.py
+++ b/main.py
@@ -7,13 +7,13 @@ from tools import mcp, scraper
 parser = argparse.ArgumentParser(description="Web Scraper MCP Server")
 parser.add_argument(
     "--log-level",
-    default="INFO",
+    default="WARNING",
     help="Logging level (debug, info, warning, error, critical)",
 )
 args, _ = parser.parse_known_args()
 
 log_file = os.path.join(os.path.expanduser("~"), "Downloads", "mcp.log")
-log_level = getattr(logging, args.log_level.upper(), logging.INFO)
+log_level = getattr(logging, args.log_level.upper(), logging.WARNING)
 logging.basicConfig(
     level=log_level,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",

--- a/mcp.json
+++ b/mcp.json
@@ -49,7 +49,7 @@
         "interval": 30
       },
       "logging": {
-        "level": "info",
+        "level": "warning",
         "file": "mcp.log"
       },
       "commands": {

--- a/tools/webscraper.py
+++ b/tools/webscraper.py
@@ -30,6 +30,7 @@ user_agent = (
 )
 chrome_options.add_argument(f'--user-agent={user_agent}')
 
+
 def _get_chrome_binary() -> Optional[str]:
     """Return the Chrome executable path or None if not found."""
     env_binary = os.getenv("CHROME_BINARY")


### PR DESCRIPTION
## Summary
- use warning as the default log level
- update config and docs for new default
- fix lint issue in webscraper

## Testing
- `ruff check .`
- `./.venv/bin/flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866469c825c832b9c52f571b050636e