### PR TITLE
add react browser tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A web scraping server that implements the Minecraft Control Protocol (MCP) using
 - Language detection
 - Headless Chrome browser automation
 - Open URLs in your existing browser session
+- Multi-step website actions with Playwright
 - FastAPI-based REST API
 - MCP protocol implementation
 
@@ -108,6 +109,19 @@ python agents_stream_tools.py "your question here"
   }
   ```
 - **Response**: Confirmation that the URL was opened using your browser session
+
+#### React Browser Task
+- **URL**: `/mcp`
+- **Method**: POST
+- **Command**: `react_browser_task`
+- **Parameters**:
+  ```json
+  {
+    "url": "https://example.com",
+    "goal": "Click the next button and return the page text"
+  }
+  ```
+- **Response**: Final page content after completing the goal
 
 ### Health Check
 - **URL**: `/health`

--- a/mcp.json
+++ b/mcp.json
@@ -36,7 +36,8 @@
         "download pdfs from text",
         "get pdfs",
         "ping",
-        "check server"
+        "check server",
+        "react browser"
       ],
       "description": "A FastMCP server that fetches and processes web content from specified URLs using Selenium. Supports fetching website content, extracting links, and health checks.",
       "timeout": 60,
@@ -93,6 +94,21 @@
             "url": {
               "type": "string",
               "description": "The URL to open",
+              "required": true
+            }
+          }
+        },
+        "react_browser_task": {
+          "description": "Use a Playwright reAct agent to interact with a website",
+          "parameters": {
+            "url": {
+              "type": "string",
+              "description": "Starting URL",
+              "required": true
+            },
+            "goal": {
+              "type": "string",
+              "description": "Task description for the agent",
               "required": true
             }
           }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ dependencies = [
   "uvicorn==0.27.1",
   "webdriver-manager==4.0.2",
   "websocket-client==1.8.0",
+  "playwright==1.53.0",
   "wsproto==1.2.0",
   "pytest==8.4.0",
   "xxhash==3.5.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,6 +92,7 @@ urllib3==2.4.0
 uvicorn==0.27.1
 webdriver-manager==4.0.2
 websocket-client==1.8.0
+playwright==1.53.0
 wsproto==1.2.0
 xxhash==3.5.0
 yarl==1.20.1

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -5,6 +5,7 @@ from .scrape_website import scrape_website
 from .extract_links import extract_links
 from .download_pdfs_from_text import download_pdfs_from_text
 from .ping import ping
+from .react_browser import react_browser_task
 
 __all__ = [
     "mcp",
@@ -14,4 +15,5 @@ __all__ = [
     "extract_links",
     "download_pdfs_from_text",
     "ping",
+    "react_browser_task",
 ]

--- a/tools/react_browser.py
+++ b/tools/react_browser.py
@@ -1,0 +1,52 @@
+import logging
+from typing import Any, Dict
+
+from langchain_ollama import ChatOllama
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import tool
+from langgraph.prebuilt import create_react_agent
+from playwright.sync_api import sync_playwright
+
+from .mcp import mcp
+
+logger = logging.getLogger(__name__)
+
+
+@mcp.tool
+def react_browser_task(url: str, goal: str) -> Dict[str, Any]:
+    """Use a reAct loop with Playwright to accomplish a goal on a website."""
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch(headless=True)
+        page = browser.new_page()
+
+        @tool
+        def goto(target: str) -> str:
+            page.goto(target)
+            return f"navigated to {target}"
+
+        @tool
+        def click(selector: str) -> str:
+            page.click(selector)
+            return f"clicked {selector}"
+
+        @tool
+        def extract(selector: str) -> str:
+            return page.inner_text(selector)
+
+        @tool
+        def page_content() -> str:
+            return page.content()
+
+        llm = ChatOllama(model="qwen3:4b")
+        agent = create_react_agent(llm, [goto, click, extract, page_content])
+
+        goto(url)
+        result = agent.invoke({"messages": [HumanMessage(content=goal)]})
+        messages = result.get("messages", [])
+        final = messages[-1].content if messages else ""
+        browser.close()
+        return {
+            "status": "success",
+            "message": "interaction finished",
+            "data": {"content": final},
+        }


### PR DESCRIPTION
## Summary
- add Playwright dependency
- implement `react_browser_task` tool using Playwright and LangGraph
- expose the new tool through MCP and docs
- update README with instructions

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686660704290832ba6306883ec8d14f7