### PR TITLE
externalize tool prompts

### DIFF
--- a/tools/download_pdfs_from_text.py
+++ b/tools/download_pdfs_from_text.py
@@ -5,13 +5,16 @@ import re
 import requests
 
 from .mcp import mcp
+from .prompt_utils import load_prompt
 
 logger = logging.getLogger(__name__)
 
 
-@mcp.tool
+PROMPT = load_prompt("download_pdfs_from_text")
+
+
+@mcp.tool(description=PROMPT)
 def download_pdfs_from_text(text: str) -> Dict[str, Any]:
-    """Download all PDF links found in the provided text."""
     try:
         pdf_pattern = re.compile(r"https?://[^\s'\"<>]+?\.pdf", re.IGNORECASE)
         links = pdf_pattern.findall(text)
@@ -42,3 +45,6 @@ def download_pdfs_from_text(text: str) -> Dict[str, Any]:
             "message": str(e),
             "data": None,
         }
+
+
+download_pdfs_from_text.__doc__ = PROMPT

--- a/tools/extract_links.py
+++ b/tools/extract_links.py
@@ -3,13 +3,16 @@ import logging
 
 from .mcp import mcp
 from .webscraper import scraper
+from .prompt_utils import load_prompt
 
 logger = logging.getLogger(__name__)
 
 
-@mcp.tool
+PROMPT = load_prompt("extract_links")
+
+
+@mcp.tool(description=PROMPT)
 def extract_links(url: str) -> Dict[str, Any]:
-    """Extract all links from a specified URL"""
     try:
         links = scraper.extract_links(url)
         return {
@@ -24,3 +27,6 @@ def extract_links(url: str) -> Dict[str, Any]:
             "message": str(e),
             "data": None,
         }
+
+
+extract_links.__doc__ = PROMPT

--- a/tools/open_in_user_browser.py
+++ b/tools/open_in_user_browser.py
@@ -4,13 +4,16 @@ from selenium.webdriver.chrome.options import Options
 
 from .mcp import mcp
 from .webscraper import chrome_options, create_driver
+from .prompt_utils import load_prompt
 
 logger = logging.getLogger(__name__)
 
 
-@mcp.tool
+PROMPT = load_prompt("open_in_user_browser")
+
+
+@mcp.tool(description=PROMPT)
 def open_in_user_browser(url: str) -> Dict[str, Any]:
-    """Open a URL in the user's regular Chrome profile. the url MUST start with https://, prepend if not available"""
     try:
         options = Options()
         for arg in chrome_options.arguments:
@@ -27,3 +30,6 @@ def open_in_user_browser(url: str) -> Dict[str, Any]:
     except Exception as e:
         logger.error(f"Failed to open browser for {url}: {str(e)}")
         return {"status": "error", "message": str(e), "data": None}
+
+
+open_in_user_browser.__doc__ = PROMPT

--- a/tools/ping.py
+++ b/tools/ping.py
@@ -2,13 +2,19 @@ from typing import Dict, Any
 import time
 
 from .mcp import mcp
+from .prompt_utils import load_prompt
 
 
-@mcp.tool
+PROMPT = load_prompt("ping")
+
+
+@mcp.tool(description=PROMPT)
 def ping() -> Dict[str, Any]:
-    """Check if the server is responsive"""
     return {
         "status": "success",
         "message": "Pong",
         "data": {"timestamp": time.time()},
     }
+
+
+ping.__doc__ = PROMPT

--- a/tools/prompt_utils.py
+++ b/tools/prompt_utils.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+PROMPTS_DIR = Path(__file__).parent / "prompts"
+
+def load_prompt(name: str) -> str:
+    """Return the text of a prompt file."""
+    path = PROMPTS_DIR / f"{name}.txt"
+    return path.read_text()

--- a/tools/prompts/download_pdfs_from_text.txt
+++ b/tools/prompts/download_pdfs_from_text.txt
@@ -1,0 +1,7 @@
+Download PDF files referenced inside text
+
+Args:
+  text (str): Text that may include links to PDFs
+
+Returns:
+  dict: Status information and the list of downloaded files

--- a/tools/prompts/extract_links.txt
+++ b/tools/prompts/extract_links.txt
@@ -1,0 +1,7 @@
+Collect all links from a webpage
+
+Args:
+  url (str): The address to scan for links
+
+Returns:
+  dict: Status information and the list of links

--- a/tools/prompts/open_in_user_browser.txt
+++ b/tools/prompts/open_in_user_browser.txt
@@ -1,0 +1,7 @@
+Open a URL using the user's normal Chrome profile
+
+Args:
+  url (str): The address to open; https:// is added if missing
+
+Returns:
+  dict: Status information and the page source

--- a/tools/prompts/ping.txt
+++ b/tools/prompts/ping.txt
@@ -1,0 +1,7 @@
+Check if the server is alive
+
+Args:
+  None
+
+Returns:
+  dict: Status information and a timestamp

--- a/tools/prompts/react_browser_task.txt
+++ b/tools/prompts/react_browser_task.txt
@@ -1,0 +1,8 @@
+Use a Playwright reAct agent to accomplish a goal on a website
+
+Args:
+  url (str): Starting page
+  goal (str): Instructions for the agent
+
+Returns:
+  dict: Status information and the final content produced

--- a/tools/prompts/scrape_website.txt
+++ b/tools/prompts/scrape_website.txt
@@ -1,0 +1,7 @@
+Scrape a webpage to extract plain text content
+
+Args:
+  url (str): The address of the webpage
+
+Returns:
+  dict: Status information and the cleaned text

--- a/tools/react_browser.py
+++ b/tools/react_browser.py
@@ -8,13 +8,16 @@ from langgraph.prebuilt import create_react_agent
 from playwright.sync_api import sync_playwright
 
 from .mcp import mcp
+from .prompt_utils import load_prompt
 
 logger = logging.getLogger(__name__)
 
 
-@mcp.tool
+PROMPT = load_prompt("react_browser_task")
+
+
+@mcp.tool(description=PROMPT)
 def react_browser_task(url: str, goal: str) -> Dict[str, Any]:
-    """Use a reAct loop with Playwright to accomplish a goal on a website."""
     with sync_playwright() as pw:
         browser = pw.chromium.launch(headless=True)
         page = browser.new_page()
@@ -50,3 +53,6 @@ def react_browser_task(url: str, goal: str) -> Dict[str, Any]:
             "message": "interaction finished",
             "data": {"content": final},
         }
+
+
+react_browser_task.__doc__ = PROMPT

--- a/tools/scrape_website.py
+++ b/tools/scrape_website.py
@@ -3,13 +3,16 @@ import logging
 
 from .mcp import mcp
 from .webscraper import scraper
+from .prompt_utils import load_prompt
 
 logger = logging.getLogger(__name__)
 
 
-@mcp.tool
+PROMPT = load_prompt("scrape_website")
+
+
+@mcp.tool(description=PROMPT)
 def scrape_website(url: str) -> Dict[str, Any]:
-    """Scrape content from a specified URL"""
     try:
         content = scraper.fetch_content(url)
         return {
@@ -24,3 +27,6 @@ def scrape_website(url: str) -> Dict[str, Any]:
             "message": str(e),
             "data": None,
         }
+
+
+scrape_website.__doc__ = PROMPT


### PR DESCRIPTION
## Summary
- store tool prompts as text files
- load those prompts when declaring tools
- add helper for reading prompt files

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b821b3104832b88ad800b7605db69