### PR TITLE
add logging for agents

### DIFF
--- a/tools/prompt_utils.py
+++ b/tools/prompt_utils.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 PROMPTS_DIR = Path(__file__).parent / "prompts"
 
+
 def load_prompt(name: str) -> str:
     """Return the text of a prompt file."""
     path = PROMPTS_DIR / f"{name}.txt"

--- a/tools/webscraper.py
+++ b/tools/webscraper.py
@@ -2,7 +2,6 @@ import logging
 import os
 import re
 import shutil
-import time
 from typing import Optional, List, Dict
 from urllib.parse import urljoin
 


### PR DESCRIPTION
## Summary
- configure logging for agents_stream_tools
- fix linter warnings in prompt_utils and webscraper

## Testing
- `flake8`
- `ruff check`


------
https://chatgpt.com/codex/tasks/task_e_686f35fe78a0832ba84a78460448d5a7