### PR TITLE
add unified log directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,12 +138,14 @@ Once the server is running, you can access the API documentation at:
 
 ## Logging
 
-Logs are written to `~/Downloads/mcp.log` and include:
-- Server startup/shutdown events
-- Web scraping operations
-- Error messages and exceptions
-You can adjust the verbosity with the `--log-level` flag when starting the server.
-By default, logs use the `warning` level.
+Server logs are written to `~/Documents/webdocs-mcp-logs/mcp.log` and include:
+ - Server startup/shutdown events
+ - Web scraping operations
+ - Error messages and exceptions
+The `agents_stream_tools.py` script logs to `~/Documents/webdocs-mcp-logs/agent.log`.
+Both sets of logs are stored in the same directory and the agent output captures tool calls and the `<think>` sections for full traceability.
+You can adjust server verbosity with the `--log-level` flag when starting the server.
+By default, server logs use the `warning` level.
 
 ## Project Structure
 

--- a/agents.md
+++ b/agents.md
@@ -52,7 +52,8 @@ uv pip install -r requirements.txt
 - Environment variables in `.env`:
   - `PORT`: Server port (default: 8000)
 - Logging configuration:
-  - Logs are written to `~/Downloads/mcp.log`
+  - Logs are written to `~/Documents/webdocs-mcp-logs/mcp.log`
+  - `agents_stream_tools.py` logs to `~/Documents/webdocs-mcp-logs/agent.log`
 
 ## Common Tasks
 

--- a/agents_stream_tools.py
+++ b/agents_stream_tools.py
@@ -1,4 +1,6 @@
 import json
+import logging
+import os
 from typing import Any, Callable, Dict, Iterable, List, Optional
 
 from rich.console import Console
@@ -13,6 +15,17 @@ from tools import (
 )
 
 console = Console()
+
+log_dir = os.path.join(os.path.expanduser("~"), "Documents", "webdocs-mcp-logs")
+os.makedirs(log_dir, exist_ok=True)
+log_file = os.path.join(log_dir, "agent.log")
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(), logging.FileHandler(log_file)],
+)
+logger = logging.getLogger(__name__)
 
 
 # Map tool names to their underlying functions for Ollama
@@ -31,11 +44,13 @@ def _invoke_tool(name: str, args: Dict[str, Any]) -> Dict[str, Any]:
     console.print(f"[cyan]Calling function: {name}[/cyan]")
     console.print(f"[cyan]Arguments: {args}[/cyan]")
     console.print()
+    logger.info("calling function %s with args %s", name, args)
     if not func:
         return {"status": "error", "message": f"unknown tool {name}", "data": None}
     try:
         return func(**args)
     except Exception as exc:  # noqa: BLE001
+        logger.exception("error during tool execution: %s", exc)
         return {"status": "error", "message": str(exc), "data": None}
 
 
@@ -52,6 +67,7 @@ DEFAULT_SYSTEM_PROMPT = (
 
 def run(query: str) -> None:
     """Stream a response, executing tools as needed."""
+    logger.info("received query: %s", query)
     messages: List[Dict[str, Any]] = [
         {"role": "system", "content": DEFAULT_SYSTEM_PROMPT},
         {"role": "user", "content": query},
@@ -61,11 +77,13 @@ def run(query: str) -> None:
     while True:
         final: Optional[ChatResponse] = None
         tool_calls = []
+        output_buffer = ""
 
         for chunk in _stream_chat(messages):
             final = chunk
             if chunk.message.content:
                 text = chunk.message.content
+                output_buffer += text
                 if "<think>" in text:
                     in_think = True
                 style = "yellow" if in_think else "green"
@@ -75,6 +93,8 @@ def run(query: str) -> None:
             if chunk.message.tool_calls:
                 tool_calls.extend(chunk.message.tool_calls)
         console.print()
+        if output_buffer:
+            logger.info("agent output: %s", output_buffer)
 
         if not final:
             break
@@ -95,7 +115,9 @@ if __name__ == "__main__":
     from tools.webscraper import scraper
 
     query = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else input("Query: ")
+    logger.info("starting agent")
     try:
         run(query)
     finally:
         scraper.cleanup()
+        logger.info("agent shutdown")

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -12,7 +12,9 @@ parser.add_argument(
 )
 args, _ = parser.parse_known_args()
 
-log_file = os.path.join(os.path.expanduser("~"), "Downloads", "mcp.log")
+log_dir = os.path.join(os.path.expanduser("~"), "Documents", "webdocs-mcp-logs")
+os.makedirs(log_dir, exist_ok=True)
+log_file = os.path.join(log_dir, "mcp.log")
 log_level = getattr(logging, args.log_level.upper(), logging.WARNING)
 logging.basicConfig(
     level=log_level,

--- a/tools/webscraper.py
+++ b/tools/webscraper.py
@@ -2,7 +2,6 @@ import logging
 import os
 import re
 import shutil
-import time
 from typing import Optional, List, Dict
 from urllib.parse import urljoin
 


### PR DESCRIPTION
## Summary
- use `~/Documents/webdocs-mcp-logs` for all logs
- document the single log directory in README and agents guide

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f35fe78a0832ba84a78460448d5a7