### PR TITLE
Add debug entrypoints to scraper tools

### DIFF
--- a/tools/download_pdfs_from_text.py
+++ b/tools/download_pdfs_from_text.py
@@ -48,3 +48,24 @@ def download_pdfs_from_text(text: str) -> Dict[str, Any]:
 
 
 download_pdfs_from_text.__doc__ = PROMPT
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+    from pathlib import Path
+
+    parser = argparse.ArgumentParser(
+        description="download pdf files referenced in text"
+    )
+    parser.add_argument("input", help="text or path to a file containing text")
+    parser.add_argument(
+        "--file",
+        action="store_true",
+        help="treat input argument as a file path",
+    )
+    args = parser.parse_args()
+
+    text = Path(args.input).read_text() if args.file else args.input
+    result = download_pdfs_from_text(text)
+    print(json.dumps(result, indent=2))

--- a/tools/extract_links.py
+++ b/tools/extract_links.py
@@ -56,3 +56,17 @@ def extract_links(content: str) -> Dict[str, Any]:
 
 
 extract_links.__doc__ = PROMPT
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+
+    parser = argparse.ArgumentParser(
+        description="extract links from a url or html snippet"
+    )
+    parser.add_argument("content", help="url or html content")
+    args = parser.parse_args()
+
+    result = extract_links(args.content)
+    print(json.dumps(result, indent=2))

--- a/tools/mcp.py
+++ b/tools/mcp.py
@@ -1,3 +1,7 @@
 from fastmcp import FastMCP
 
 mcp = FastMCP("Web Scraper MCP 🚀")
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/tools/open_in_user_browser.py
+++ b/tools/open_in_user_browser.py
@@ -33,3 +33,17 @@ def open_in_user_browser(url: str) -> Dict[str, Any]:
 
 
 open_in_user_browser.__doc__ = PROMPT
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+
+    parser = argparse.ArgumentParser(
+        description="open a url in the user browser and return page source"
+    )
+    parser.add_argument("url", help="the page to open")
+    args = parser.parse_args()
+
+    result = open_in_user_browser(args.url)
+    print(json.dumps(result, indent=2))

--- a/tools/ping.py
+++ b/tools/ping.py
@@ -18,3 +18,9 @@ def ping() -> Dict[str, Any]:
 
 
 ping.__doc__ = PROMPT
+
+
+if __name__ == "__main__":
+    import json
+
+    print(json.dumps(ping(), indent=2))

--- a/tools/react_browser.py
+++ b/tools/react_browser.py
@@ -56,3 +56,18 @@ def react_browser_task(url: str, goal: str) -> Dict[str, Any]:
 
 
 react_browser_task.__doc__ = PROMPT
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+
+    parser = argparse.ArgumentParser(
+        description="use an llm to interact with a page via playwright"
+    )
+    parser.add_argument("url", help="starting page url")
+    parser.add_argument("goal", help="task description")
+    args = parser.parse_args()
+
+    result = react_browser_task(args.url, args.goal)
+    print(json.dumps(result, indent=2))

--- a/tools/scrape_website.py
+++ b/tools/scrape_website.py
@@ -30,3 +30,16 @@ async def scrape_website(url: str) -> Dict[str, Any]:
 
 
 scrape_website.__doc__ = PROMPT
+
+
+if __name__ == "__main__":
+    import argparse
+    import asyncio
+    import json
+
+    parser = argparse.ArgumentParser(description="scrape the main text of a website")
+    parser.add_argument("url", help="page to scrape")
+    args = parser.parse_args()
+
+    result = asyncio.run(scrape_website(args.url))
+    print(json.dumps(result, indent=2))

--- a/tools/webscraper.py
+++ b/tools/webscraper.py
@@ -288,3 +288,34 @@ class WebScraper:
 # The scraper instance can be created synchronously; its heavy resources
 # are loaded lazily when the first async method is awaited.
 scraper = WebScraper()
+
+
+if __name__ == "__main__":
+    import argparse
+    import asyncio
+    import json
+
+    parser = argparse.ArgumentParser(description="basic cli for the WebScraper")
+    parser.add_argument("url", help="page to fetch")
+    parser.add_argument(
+        "--mode",
+        choices=["playwright", "selenium"],
+        default="playwright",
+        help="scraper mode",
+    )
+    parser.add_argument(
+        "--links",
+        action="store_true",
+        help="extract links instead of text content",
+    )
+    args = parser.parse_args()
+
+    scraper = WebScraper(mode=args.mode)
+    try:
+        if args.links:
+            data = asyncio.run(scraper.extract_links(args.url))
+        else:
+            data = asyncio.run(scraper.fetch_content(args.url))
+        print(json.dumps(data, indent=2))
+    finally:
+        asyncio.run(scraper.cleanup())


### PR DESCRIPTION
## Summary
- add `__main__` blocks to each tool module for CLI usage
- expose a simple run helper in `tools/mcp.py`

## Testing
- `ruff check --quiet`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686fc12b6fe4832b89a656d230d64795