### PR TITLE
Update scrape tool to filter relevant content

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,11 @@ python agents_stream_tools.py "your question here"
 - **Parameters**:
   ```json
   {
-    "url": "https://example.com"
+    "url": "https://example.com",
+    "query": "specific topic"
   }
   ```
-- **Response**: Extracted and cleaned content from the webpage
+- **Response**: Filtered content relevant to the query
 
 #### Extract Links
 - **URL**: `/mcp`

--- a/agents.md
+++ b/agents.md
@@ -44,7 +44,7 @@ uv pip install -r requirements.txt
 
 ### 1. MCP Endpoints (`mcp_server.py`)
 - `/mcp` endpoint handling:
-  - `scrape_website`: Extracts and cleans web content
+  - `scrape_website`: Returns text related to a query from a webpage
   - `extract_links`: Collects links from raw HTML. If given a URL, it fetches the page first.
   - `ping`: Server status check
 

--- a/mcp.json
+++ b/mcp.json
@@ -54,12 +54,17 @@
         "file": "mcp.log"
       },
       "commands": {
-        "fetch_website": {
-          "description": "Fetch content from a specified URL using Selenium",
+        "scrape_website": {
+          "description": "Fetch and filter web content relevant to a query",
           "parameters": {
             "url": {
               "type": "string",
               "description": "The URL to fetch content from",
+              "required": true
+            },
+            "query": {
+              "type": "string",
+              "description": "Information to look for on the page",
               "required": true
             }
           }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ dependencies = [
   "xxhash==3.5.0",
   "zstandard==0.23.0",
   "pyperclip==1.8.2",
+  "nltk==3.9.1",
   "flake8==7.2.0",
   "langchain-ollama==0.3.3",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ openapi-pydantic==0.5.1
 orjson==3.10.18
 ormsgpack==1.10.0
 outcome==1.3.0.post0
+package-name==0.1
 packaging==24.2
 pip==25.1.1
 playwright==1.53.0
@@ -51,6 +52,7 @@ pyee==13.0.0
 pyflakes==3.3.2
 pygments==2.19.1
 pyperclip==1.8.2
+nltk==3.9.1
 pysocks==1.7.1
 pytest==8.4.0
 python-dotenv==1.1.0

--- a/tools/prompts/scrape_website.txt
+++ b/tools/prompts/scrape_website.txt
@@ -1,7 +1,8 @@
-Scrape a webpage to extract plain text content
+Scrape a webpage and return only text relevant to a query
 
 Args:
   url (str): The address of the webpage
+  query (str): What information to search for on the page
 
 Returns:
-  dict: Status information and the cleaned text
+  dict: Status information and the filtered text

--- a/tools/scrape_website.py
+++ b/tools/scrape_website.py
@@ -1,5 +1,8 @@
 from typing import Dict, Any
 import logging
+import re
+from nltk.stem import PorterStemmer
+from nltk.tokenize import word_tokenize
 
 from .mcp import mcp
 from .webscraper import scraper
@@ -9,12 +12,39 @@ logger = logging.getLogger(__name__)
 
 
 PROMPT = load_prompt("scrape_website")
+_stemmer = PorterStemmer()
+
+
+def _tokenize(text: str) -> set[str]:
+    tokens = word_tokenize(text)
+    return { _stemmer.stem(t.lower()) for t in tokens if t.isalpha() }
+
+
+def _filter_content(content: str, query: str, max_sentences: int = 5) -> str:
+    sentences = re.split(r"(?<=[.!?])\s+", content)
+    query_tokens = _tokenize(query)
+    scored: list[tuple[float, str]] = []
+    for sentence in sentences:
+        sent_tokens = _tokenize(sentence)
+        if not sent_tokens:
+            continue
+        intersection = query_tokens & sent_tokens
+        union = query_tokens | sent_tokens
+        score = len(intersection) / len(union) if union else 0
+        if score:
+            scored.append((score, sentence.strip()))
+    scored.sort(key=lambda x: x[0], reverse=True)
+    if not scored:
+        return " ".join(sentences[:max_sentences])
+    relevant = [s for _, s in scored[:max_sentences]]
+    return " ".join(relevant)
 
 
 @mcp.tool(description=PROMPT)
-async def scrape_website(url: str) -> Dict[str, Any]:
+async def scrape_website(url: str, query: str) -> Dict[str, Any]:
     try:
         content = await scraper.fetch_content(url)
+        content = _filter_content(content, query)
         return {
             "status": "success",
             "no. of characters": len(content),
@@ -37,9 +67,10 @@ if __name__ == "__main__":
     import asyncio
     import json
 
-    parser = argparse.ArgumentParser(description="scrape the main text of a website")
+    parser = argparse.ArgumentParser(description="scrape relevant text from a website")
     parser.add_argument("url", help="page to scrape")
+    parser.add_argument("query", help="information to look for")
     args = parser.parse_args()
 
-    result = asyncio.run(scrape_website(args.url))
+    result = asyncio.run(scrape_website(args.url, args.query))
     print(json.dumps(result, indent=2))


### PR DESCRIPTION
## Summary
- implement query-based content filtering for `scrape_website`
- use NLTK stemming and tokenization to rank relevant sentences
- document new `query` parameter in README and prompts
- update agents guide and `mcp.json`
- add nltk to project dependencies

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875bc543b50832ba9f1731a431692f0