### PR TITLE
fix agent plan retention

### DIFF
--- a/agents_stream_tools.py
+++ b/agents_stream_tools.py
@@ -104,7 +104,11 @@ def run(query: str) -> None:
 
         if not final:
             break
-        messages.append(final.message.model_dump())
+
+        assistant_message = {"role": "assistant", "content": output_buffer}
+        if tool_calls:
+            assistant_message["tool_calls"] = [c.model_dump() for c in tool_calls]
+        messages.append(assistant_message)
 
         if not tool_calls:
             break

--- a/tools/scrape_website.py
+++ b/tools/scrape_website.py
@@ -17,7 +17,7 @@ _stemmer = PorterStemmer()
 
 def _tokenize(text: str) -> set[str]:
     tokens = word_tokenize(text)
-    return { _stemmer.stem(t.lower()) for t in tokens if t.isalpha() }
+    return {_stemmer.stem(t.lower()) for t in tokens if t.isalpha()}
 
 
 def _filter_content(content: str, query: str, max_sentences: int = 5) -> str:


### PR DESCRIPTION
## Summary
- fix message accumulation in `agents_stream_tools.py` so the agent keeps its plan across tool calls
- clean up `_tokenize` in `scrape_website.py`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687634849e20832ba09e37da56f37eee