### PR TITLE
implement truncated tool output memory

### DIFF
--- a/agents_stream_tools.py
+++ b/agents_stream_tools.py
@@ -19,6 +19,9 @@ from tools import (
 
 console = Console()
 
+TRUNCATE_AT = 2000
+FULL_OUTPUT_PLACEHOLDER = "<FULL_TOOL_OUTPUT>"
+
 project_dir = os.path.dirname(os.path.abspath(__file__))
 log_dir = os.path.join(project_dir, "logs")
 os.makedirs(log_dir, exist_ok=True)
@@ -67,7 +70,9 @@ def _stream_chat(messages: List[Dict[str, Any]]) -> Iterable[ChatResponse]:
 
 DEFAULT_SYSTEM_PROMPT = (
     "The web scraper defaults to Playwright mode. "
-    "Use Selenium only when a user explicitly requests cookie-based browsing."
+    "Use Selenium only when a user explicitly requests cookie-based browsing. "
+    "Tool outputs may be truncated. Use "
+    f"{FULL_OUTPUT_PLACEHOLDER} to reference the previous full output when calling new tools."
 )
 
 
@@ -79,6 +84,7 @@ def run(query: str) -> None:
         {"role": "user", "content": query},
     ]
     in_think = False
+    last_tool_output: Optional[str] = None
 
     while True:
         final: Optional[ChatResponse] = None
@@ -116,8 +122,18 @@ def run(query: str) -> None:
         for call in tool_calls:
             name = call.function.name
             args = call.function.arguments or {}
+            # replace placeholder with the stored full tool output
+            for key, value in list(args.items()):
+                if isinstance(value, str) and FULL_OUTPUT_PLACEHOLDER in value:
+                    args[key] = value.replace(FULL_OUTPUT_PLACEHOLDER, last_tool_output or "")
+
             result = _invoke_tool(name, args)
-            messages.append({"role": "tool", "name": name, "content": json.dumps(result)})
+            full_output = json.dumps(result)
+            last_tool_output = full_output
+            truncated = full_output[:TRUNCATE_AT]
+            if len(full_output) > TRUNCATE_AT:
+                truncated += "...\n[output truncated; use " + FULL_OUTPUT_PLACEHOLDER + " to reference full output]"
+            messages.append({"role": "tool", "name": name, "content": truncated})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add truncation and placeholder storage for tool output
- explain placeholder usage to assistant in system prompt

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687708405440832ba58a3c8a19190d5a