### PR TITLE
Fix unawaited cleanup calls

### DIFF
--- a/agents_stream_tools.py
+++ b/agents_stream_tools.py
@@ -152,5 +152,5 @@ if __name__ == "__main__":
     try:
         run(query)
     finally:
-        scraper.cleanup()
+        asyncio.run(scraper.cleanup())
         logger.info("agent shutdown")

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import os
+import asyncio
 
 from tools import mcp, scraper
 
@@ -28,4 +29,4 @@ if __name__ == "__main__":
     try:
         mcp.run()
     finally:
-        scraper.cleanup()
+        asyncio.run(scraper.cleanup())


### PR DESCRIPTION
## Summary
- ensure scraper cleanup runs asynchronously in scripts

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687dda0afc58832b8cbae402291013a0