### PR TITLE
Improve message management for agent

### DIFF
--- a/agents_stream_tools.py
+++ b/agents_stream_tools.py
@@ -22,6 +22,41 @@ console = Console()
 TRUNCATE_AT = 2000
 FULL_OUTPUT_PLACEHOLDER = "<FULL_TOOL_OUTPUT>"
 
+
+def _minify_result(result: Dict[str, Any]) -> Dict[str, Any]:
+    """Reduce tool result size by dropping unnecessary fields."""
+    if result.get("status") == "error":
+        return {"error": result.get("message")}
+    if "data" in result:
+        return {"data": result["data"]}
+    return {}
+
+
+def _minify_tool_call(call: Any) -> Dict[str, Any]:
+    """Remove extraneous fields from a tool call object."""
+    data = call.model_dump()
+    data.pop("id", None)
+    data.pop("type", None)
+    return data
+
+
+def _trim_history(messages: List[Dict[str, Any]], plan_index: Optional[int]) -> Optional[int]:
+    """Keep the system prompt, user query, initial plan and recent messages."""
+    if plan_index is None:
+        for i, msg in enumerate(messages):
+            if msg.get("role") == "assistant":
+                plan_index = i
+                break
+
+    keep = {0, 1}
+    if plan_index is not None:
+        keep.add(plan_index)
+    start = max(len(messages) - 4, max(keep) + 1 if keep else 0)
+    keep.update(range(start, len(messages)))
+    messages[:] = [m for i, m in enumerate(messages) if i in keep]
+    return plan_index
+
+
 project_dir = os.path.dirname(os.path.abspath(__file__))
 log_dir = os.path.join(project_dir, "logs")
 os.makedirs(log_dir, exist_ok=True)
@@ -87,13 +122,12 @@ def run(query: str) -> None:
     ]
     in_think = False
     last_tool_output: Optional[str] = None
+    plan_index: Optional[int] = None
 
     while True:
         final: Optional[ChatResponse] = None
         tool_calls = []
         output_buffer = ""
-        print("messages size:", len(str(messages)))
-        print(messages)
         for chunk in _stream_chat(messages):
             final = chunk
             if chunk.message.content:
@@ -116,10 +150,11 @@ def run(query: str) -> None:
 
         assistant_message = {"role": "assistant", "content": output_buffer}
         if tool_calls:
-            assistant_message["tool_calls"] = [c.model_dump() for c in tool_calls]
+            assistant_message["tool_calls"] = [_minify_tool_call(c) for c in tool_calls]
         messages.append(assistant_message)
 
         if not tool_calls:
+            plan_index = _trim_history(messages, plan_index)
             break
 
         for call in tool_calls:
@@ -131,7 +166,8 @@ def run(query: str) -> None:
                     args[key] = value.replace(FULL_OUTPUT_PLACEHOLDER, last_tool_output or "")
 
             result = _invoke_tool(name, args)
-            full_output = json.dumps(result)
+            minified = _minify_result(result)
+            full_output = json.dumps(minified, separators=(",", ":"))
             last_tool_output = full_output
             truncated = full_output
             if len(full_output) > TRUNCATE_AT:
@@ -141,6 +177,8 @@ def run(query: str) -> None:
                     + f"...\n[output truncated, {omitted} chars omitted; use {FULL_OUTPUT_PLACEHOLDER} for full output]"
                 )
             messages.append({"role": "tool", "name": name, "content": truncated})
+
+        plan_index = _trim_history(messages, plan_index)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- trim conversation history to maintain only key messages
- minify stored tool calls and results to reduce context size

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687de5bc098c832b96538e636739a47d