### PR TITLE
externalize model selection

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -10,6 +10,8 @@ from langgraph.prebuilt import create_react_agent  # noqa: E402
 from ollama import Client  # noqa: E402
 from rich.console import Console  # noqa: E402
 
+from settings import get_setting  # noqa: E402
+
 from tools import (  # noqa: E402
     open_in_user_browser,
     scrape_website,
@@ -18,7 +20,7 @@ from tools import (  # noqa: E402
     ping,
 )
 
-llm = ChatOllama(model="qwen3:4b")
+llm = ChatOllama(model=get_setting("react_model", "qwen3:4b"))
 client = Client()
 console = Console()
 
@@ -43,7 +45,7 @@ def run(query: str) -> str:
 def stream(query: str) -> None:
     """Stream response tokens for the given query."""
     stream = client.chat(
-        model="qwen3:4b",
+        model=get_setting("react_model", "qwen3:4b"),
         messages=[{"role": "user", "content": query}],
         stream=True,
     )

--- a/agents_stream_prompt.py
+++ b/agents_stream_prompt.py
@@ -10,6 +10,8 @@ import inspect
 from rich.console import Console
 from ollama import chat, ChatResponse
 
+from settings import get_setting
+
 from tools import (
     open_in_user_browser,
     scrape_website,
@@ -68,7 +70,8 @@ def _invoke_tool(name: str, args: Dict[str, Any]) -> Dict[str, Any]:
 
 def _stream_chat(messages: List[Dict[str, Any]]) -> Iterable[ChatResponse]:
     """Yield chat responses from Ollama with streaming enabled."""
-    return chat(model="llama3.1:8b", messages=messages, stream=True)
+    model = get_setting("stream_model", "llama3.1:8b")
+    return chat(model=model, messages=messages, stream=True)
 
 
 

--- a/agents_stream_tools.py
+++ b/agents_stream_tools.py
@@ -9,6 +9,8 @@ import inspect
 from rich.console import Console
 from ollama import chat, ChatResponse
 
+from settings import get_setting
+
 from tools import (
     open_in_user_browser,
     scrape_website,
@@ -100,7 +102,8 @@ def _invoke_tool(name: str, args: Dict[str, Any]) -> Dict[str, Any]:
 
 def _stream_chat(messages: List[Dict[str, Any]]) -> Iterable[ChatResponse]:
     """Yield chat responses from Ollama with streaming enabled."""
-    return chat(model="llama3.1:8b", messages=messages, tools=list(TOOL_MAP.values()), stream=True)
+    model = get_setting("stream_model", "llama3.1:8b")
+    return chat(model=model, messages=messages, tools=list(TOOL_MAP.values()), stream=True)
 
 
 DEFAULT_SYSTEM_PROMPT = (

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,4 @@
+{
+  "stream_model": "llama3.1:8b",
+  "react_model": "qwen3:4b"
+}

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+SETTINGS_PATH = Path(__file__).with_name("settings.json")
+
+try:
+    with SETTINGS_PATH.open("r") as f:
+        _SETTINGS = json.load(f)
+except FileNotFoundError:
+    _SETTINGS = {}
+
+
+def get_setting(key: str, default: str | None = None) -> str | None:
+    """Return the configured value for ``key`` or ``default`` if missing."""
+    return _SETTINGS.get(key, default)

--- a/tools/react_browser.py
+++ b/tools/react_browser.py
@@ -7,6 +7,8 @@ from langchain_core.tools import tool
 from langgraph.prebuilt import create_react_agent
 from playwright.sync_api import sync_playwright
 
+from settings import get_setting
+
 from .mcp import mcp
 from .prompt_utils import load_prompt
 
@@ -40,7 +42,7 @@ def react_browser_task(url: str, goal: str) -> Dict[str, Any]:
         def page_content() -> str:
             return page.content()
 
-        llm = ChatOllama(model="qwen3:4b")
+        llm = ChatOllama(model=get_setting("react_model", "qwen3:4b"))
         agent = create_react_agent(llm, [goto, click, extract, page_content])
 
         goto(url)


### PR DESCRIPTION
## Summary
- add `settings.json` and `settings.py` for configurable model names
- load model names from settings in `agents_stream_prompt.py`, `agents_stream_tools.py`, `agents.py`, and `react_browser.py`

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886feb88a10832bb2a274fe0296789a