### PR TITLE
improve planner and executor coordination

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -56,3 +56,39 @@ langgraph_mod = types.ModuleType("langgraph")
 langgraph_mod.prebuilt = prebuilt_mod
 sys.modules.setdefault("langgraph", langgraph_mod)
 sys.modules.setdefault("langgraph.prebuilt", prebuilt_mod)
+
+ollama_mod = types.ModuleType("ollama")
+
+
+def _ollama_chat(*args, **kwargs):
+    class R:
+        def __init__(self) -> None:
+            self.message = types.SimpleNamespace(content="")
+
+    yield R()
+
+
+ollama_mod.chat = _ollama_chat
+ollama_mod.ChatResponse = object
+sys.modules.setdefault("ollama", ollama_mod)
+
+playwright_mod = types.ModuleType("playwright")
+async_api_mod = types.ModuleType("async_api")
+sync_api_mod = types.ModuleType("sync_api")
+async_api_mod.async_playwright = lambda: None
+sync_api_mod.sync_playwright = lambda: None
+playwright_mod.async_api = async_api_mod
+playwright_mod.sync_api = sync_api_mod
+sys.modules.setdefault("playwright", playwright_mod)
+sys.modules.setdefault("playwright.async_api", async_api_mod)
+sys.modules.setdefault("playwright.sync_api", sync_api_mod)
+
+web_mod = types.ModuleType("web")
+
+
+def _web_run(*args, **kwargs):
+    return ""
+
+
+web_mod.run = _web_run
+sys.modules.setdefault("web", web_mod)

--- a/tests/test_agents_stream_tools.py
+++ b/tests/test_agents_stream_tools.py
@@ -1,0 +1,38 @@
+import json
+from unittest.mock import patch
+
+import agents_stream_tools as ast
+
+
+def test_planner_produces_plan():
+    shared = {"plan": "", "execution": "", "summary": "", "plan_json": []}
+    out = "<plan>{\"tool\": \"scrape_website\", \"purpose\": \"grab\"}\n</plan>"
+    with patch.object(ast.PlannerAgent, "_chat", return_value=out):
+        plan = ast.PlannerAgent("q", shared).run()
+    assert plan and plan[0]["tool"] in ast.AVAILABLE_TOOLS
+    assert shared["plan_json"] == plan
+
+
+def test_executor_dynamic_tool_invocation():
+    shared = {"plan": "plan", "execution": "", "summary": "", "plan_json": []}
+    tool_map = {"scrape_website": lambda url: {"data": url}}
+    step = {"tool": "scrape_website", "purpose": "grab"}
+    with patch("agents_stream_tools.get_available_tools", return_value=tool_map):
+        with patch.object(ast.ExecutorAgent, "_chat", return_value='<tool>{"tool":"scrape_website","args":{"q":"latest cars"}}</tool>'):
+            with patch("agents_stream_tools._invoke_tool", return_value={"data": "ok"}) as inv:
+                result = ast.ExecutorAgent([step], "latest cars", shared).run()
+    inv.assert_called_once_with("scrape_website", {"q": "latest cars"}, tool_map=tool_map, debug=False)
+    assert json.loads(result)["data"] == "ok" or result == ""
+
+
+def test_full_pipeline():
+    shared = {"plan": "", "execution": "", "summary": "", "plan_json": []}
+    planner_out = "<plan>{\"tool\": \"scrape_website\", \"purpose\": \"grab\"}\n</plan>"
+    with patch.object(ast.PlannerAgent, "_chat", return_value=planner_out):
+        with patch.object(ast.ExecutorAgent, "_chat", return_value='<tool>{"tool":"scrape_website","args":{}}</tool>'):
+            with patch("agents_stream_tools._invoke_tool", return_value={"data": "ok"}):
+                with patch.object(ast.SummarizerAgent, "_chat", return_value="<final>done</final>"):
+                    agent = ast.StreamingAgent(query="q", shared=shared)
+                    agent.run()
+    assert shared["summary"] == "<final>done</final>"
+

--- a/tool_registry.py
+++ b/tool_registry.py
@@ -1,0 +1,18 @@
+from importlib import import_module
+from typing import Callable, Dict, Any
+
+from tools import __all__ as tool_names
+
+
+def get_available_tools() -> Dict[str, Callable[..., Any]]:
+    """Return mapping of tool names to callables discovered from tools package."""
+    mapping: Dict[str, Callable[..., Any]] = {}
+    for name in tool_names:
+        try:
+            module = import_module(f"tools.{name}")
+        except Exception:
+            continue
+        func = getattr(module, name, None)
+        if callable(func):
+            mapping[name] = func
+    return mapping


### PR DESCRIPTION
## Summary
- refactor agents to output and consume json-based plans
- make executor choose tools dynamically and track executed tools
- include executed tools in summarizer context
- update tests for new behavior and provide stubs for external deps

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c27361f44832b8c7ccaa1736b3bbc